### PR TITLE
Fix home page errors when diary is empty

### DIFF
--- a/pants/diary/models.py
+++ b/pants/diary/models.py
@@ -361,9 +361,9 @@ class DiaryFood(AbstractBaseNutrients):
       context['lastday_objects']=lastday_df
 
       # XXX: MUST do the sums first as we don't want to add ratios or similar
-      context['last24_sum']=add_nutrition_ratios(
+      context['last24_sum']=add_nutrition_ratios(defaultdict(Decimal,
          { k: today_total.get(k, 0) + last24_total.get(k, 0) for k in set(today_total) | set(last24_total) }
-      )
+      ))
       context['lastday_sum']=add_nutrition_ratios(
          { k: lastday_total.get(k, 0) + last24_total.get(k, 0) for k in set(lastday_total) | set(last24_total) }
       )


### PR DESCRIPTION
I attempted to follow the installation instructions and start up my own instance. After logging in and attempting to access the home page I received an error about accessing 'kilojoules' from the dictionary of data from the last 24 hours that does not have that key. It looks like you use defaultdicts to prevent this error from happening in the current day dictionary, so this pull request makes the last24_sum a defaultdict as well.