### PR TITLE
Allow local user facing login. Fix outdated names.

### DIFF
--- a/pants/pants/settings.py
+++ b/pants/pants/settings.py
@@ -133,6 +133,7 @@ STATIC_URL = '/static/'
 # Added settings below here....
 
 LOGIN_URL = '/wearpants/'
+LOGIN_REDIRECT_URL = 'website-index'
 
 # Constants used for nutritional calculations
 # DO NOT EDIT THESE

--- a/pants/pants/urls.py
+++ b/pants/pants/urls.py
@@ -16,11 +16,12 @@ Including another URLconf
 from django.conf.urls import include,url
 from django.contrib import admin
 from website import views as website
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     url(r'^$', website.index, name='website-index'),
-    url(r'^wearpants/', website.login, name='website-login'),
-    #url(r'^logout/', website.login, name='website-logout'),  # FIXME
+    url(r'^wearpants/', auth_views.LoginView.as_view(template_name='website/login.html'), name='website-login'),
+    url(r'^logout/', auth_views.LogoutView.as_view(template_name="website/logout.html"), name='website-logout'),
     url(r'^about/', website.about, name='website-about'),
 
     url(r'^diary/', include('diary.urls')),

--- a/pants/website/templates/website/login.html
+++ b/pants/website/templates/website/login.html
@@ -1,16 +1,18 @@
 {% extends 'pants/base.html' %}
 
 {% block title %}
-<title>Login - Price And Nutrition Tabulation System</title>
+<title>Login - Price And Nutrition Tracking System</title>
 {% endblock %}
 
 {% block headline %}
-<h1>Login - Price And Nutrition Tabulation System</h1>
+<h1>Login - Price And Nutrition Tracking System</h1>
 {% endblock %}
 
 {% block content %}
-
-<p>You must login via the admin interface before continuing.</p>
-
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Login</button>
+</form>
 {% endblock %}
 

--- a/pants/website/templates/website/logout.html
+++ b/pants/website/templates/website/logout.html
@@ -1,0 +1,13 @@
+{% extends 'pants/base.html' %}
+
+{% block title %}
+<title>Logout - Price And Nutrition Tracking System</title>
+{% endblock %}
+
+{% block headline %}
+<h1>Logout - Price And Nutrition Tracking System</h1>
+{% endblock %}
+
+{% block content %}
+<p>You have been logged out of the system. Click <a href="{% url 'website-login' %}">here</a> to log back in.</p>
+{% endblock %}


### PR DESCRIPTION
I saw on the TODO that having user facing login was a higher priority item. This commit uses the built in login views that Django provides to add a login form to the screen that used to say that you needed to log in from the admin view. I tested with both an admin and non-admin account.

I also updated two references to a "Price And Nutrition *Tabulation* System" to say Tracking, I assumed they were old references that were not updated at some point?

I refrained from adding any CSS, it wasn't clear what sort of styles if any should be applied, so I left it bare.